### PR TITLE
Make log-out btn less apparent in side drawer

### DIFF
--- a/client/src/components/SideDrawer.css
+++ b/client/src/components/SideDrawer.css
@@ -45,12 +45,8 @@
 }
 
 .side-drawer button {
-    font-size: 1.8rem;
-    font-weight: 500;
-    padding: 0;
-    color: #16db86;
-    border: none;
-    font-family: "Roboto", sans-serif;
+    border-color: #a1afc7 ;
+    color:#a1afc7
 }
 
 .side-drawer a:hover,


### PR DESCRIPTION
This adds to the last pull request of improving the user experience. It aims to make the log out button on side drawer less apparent. 