### PR TITLE
Replace alert popup with customised notification modal 

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,6 +4,7 @@
   "proxy": "http://localhost:5500",
   "private": true,
   "dependencies": {
+    "@material-ui/core": "^4.11.0",
     "axios": "^0.19.2",
     "react": "^16.13.1",
     "react-alice-carousel": "^1.19.3",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -74,7 +74,7 @@ class App extends Component {
           <Route
             exact
             path="/apps/:id"
-            render={(props) => <AppDetail user={this.state.user} match={props.match} />} // {...props}
+            render={(props) => <AppDetail user={this.state.user} match={props.match} history={props.history}/>} // {...props}
           />
           <Route
             exact

--- a/client/src/components/AppDetail.js
+++ b/client/src/components/AppDetail.js
@@ -7,38 +7,20 @@ import { getAverageRating, rateApp } from '../services/rating';
 import appIconPlaceholder from '../app-icon-placeholder.svg';
 import TextArea from './TextArea';
 import Loader from './Loader';
-// import Loader from './Loader_copy';
+
 import PopupModal from './PopupModal';
-import { makeStyles } from '@material-ui/core/styles';
-import Popover from '@material-ui/core/Popover';
-import Typography from '@material-ui/core/Typography';
+
 
 import './AppDetail.scss';
-import { CloudStorageIcon } from '../images';
+//import { CloudStorageIcon } from '../images';
 
 function AppDetailHook(props) {
   const [app, setApp] = useState(null);
   const [avrRating, setAvrRating] = useState(0);
-  //
-  // const [anchorEl, setAnchorEl] = useState(null);
+  // popover 
   const [open, setOpen] = useState(false);
-  const useStyles = makeStyles((theme) => ({
-    typography: {
-      padding: theme.spacing(2),
-      color: '#c5b79f',
-      backgroundColor: '#31708f',
-      boxShadow: "10px 10px 5px 0px  rgba(26, 24, 41, 0.7)",
-    },
-    // root: {
-    //   "& .MuiPaper-root": {
-        
-    //   }
-    // }
-  }));
-
-  const classes = useStyles();
-
-
+  const [openMsg, setOpenMsg] = useState(null);
+ 
   const appId = props.match.params.id;
   const userId = props.user._id;
 
@@ -70,21 +52,24 @@ function AppDetailHook(props) {
     
     rateApp(ratingValue, appId)
       .then(() => {
-        alert(`Thank you for rating ${app.name}.`); // replace it with a modal module
-        
         updateAvrRating(appId);
+        updateAppDetails();
+        setOpenMsg(`Thank you for rating ${app.name}!`);
+        setOpen(true);
       })
       .catch((error) => {
         alert(error.message);
       });
   };
 
+  // popover logics
   const handleClose = () => {
     setOpen(false);
   };
-
-  const id = open ? 'simple-popover' : null;
-
+  
+  // I want: always open only one, and change only the message
+  const confirm = open ? 'simple-popover' : null;
+  
   const updateAvrRating = () => {
     getAverageRating(appId)
       .then((averageRating) => {
@@ -115,7 +100,8 @@ function AppDetailHook(props) {
     
     addWishApp(appId, userId)
       .then(() => {
-        updateAppDetails();
+        updateAppDetails(); 
+        setOpenMsg(`${app.name} is added to wish list!`);
         setOpen(true);
       })
       .catch((error) => {
@@ -124,10 +110,11 @@ function AppDetailHook(props) {
   };
 
   // remove app from wish list
-  const removeFromWishList = (event) => {
+  const removeFromWishList = () => {
     removeWishApp(appId, userId)
       .then(() => {
         updateAppDetails();
+        setOpenMsg(`${app.name} is removed from wish list!`);
         setOpen(true);
       })
       .catch((error) => {
@@ -136,23 +123,26 @@ function AppDetailHook(props) {
   };
 
   const ratingBtns = (
-    <div>
+    <div id="rateApp">
       <h4>Rate this app</h4>
-      <button type="button" value={1} onClick={submitRating}>
-        1 ✦
-      </button>
-      <button type="button" value={2} onClick={submitRating}>
-        2 ✦ ✦
-      </button>
-      <button type="button" value={3} onClick={submitRating}>
-        3 ✦ ✦ ✦
-      </button>
-      <button type="button" value={4} onClick={submitRating}>
-        4 ✦ ✦ ✦ ✦
-      </button>
-      <button type="button" value={5} onClick={submitRating}>
-        5 ✦ ✦ ✦ ✦ ✦
-      </button>
+      <div>
+          <button type="button" value={1} onClick={submitRating}>
+            1 ✦
+          </button>
+          
+          <button type="button" value={2} onClick={submitRating}>
+            2 ✦ ✦
+          </button>
+            <button type="button" value={3} onClick={submitRating}>
+            3 ✦ ✦ ✦
+          </button>
+          <button type="button" value={4} onClick={submitRating}>
+            4 ✦ ✦ ✦ ✦
+          </button>
+          <button type="button" value={5} onClick={submitRating}>
+            5 ✦ ✦ ✦ ✦ ✦
+          </button>
+      </div>
     </div>
   );
 
@@ -161,32 +151,19 @@ function AppDetailHook(props) {
 
   const wishListBtn = (
     <div>
-    <button type="button" key={props.user._id} onClick={addToWishList} className="small">
-      + &nbsp; Wish list
-    </button>
-    <PopupModal
-     id= {id}
-     open = {open}
-     handleClose = {handleClose}
-     wishListMessage = {`${app.name} is removed from the wish list!`}
-    />
-
-   
+        <button type="button" key={props.user._id} onClick={addToWishList} className="small">
+          + &nbsp; Wish list
+         
+        </button>
   </div>
   );
 
   const removeWishListBtn = (
     <div>
-      <button type="button" key={props.user._id} onClick={removeFromWishList} className="small">
-        Saved
-      </button>
-    <PopupModal
-     id= {id}
-     open = {open}
-     handleClose = {handleClose}
-     wishListMessage = {`${app.name} is saved to the wish list!`}
-    />
-  </div>
+        <button type="button" key={props.user._id} onClick={removeFromWishList} className="small">
+          Saved
+        </button>
+    </div>
   );
 
   const wishListBtns = (
@@ -243,6 +220,12 @@ function AppDetailHook(props) {
 
   return (
     <main id="appDetail">
+      <PopupModal 
+        id= {confirm}
+        open = {open}
+        handleClose = {handleClose}
+        message = {openMsg}
+        />
       <div className="appIntro">
         {/* <Loader /> */}
         <div className="appInfo">
@@ -267,8 +250,7 @@ function AppDetailHook(props) {
       </div>
 
       <div className="labels-container">
-        {/* {props.user ? wishListBtns : null} */}
-        {wishListBtns}
+        {props.user ? wishListBtns : null}
         {props.user ? editLinkBtn : null}
       </div>
 
@@ -280,7 +262,7 @@ function AppDetailHook(props) {
           <h4>Available devices:</h4>
           <ul>{app.device && app.device.map((device, index) => <li key={index}>{device}</li>)}</ul>
         </div>
-        <div id="rateApp">{props.user ? ratingBtns : null}</div>
+        {props.user ? ratingBtns : null}
         <TextArea userId={userId} app={app} />
         {deleteBtn}
       </div>

--- a/client/src/components/AppDetail.js
+++ b/client/src/components/AppDetail.js
@@ -67,7 +67,6 @@ function AppDetailHook(props) {
     setOpen(false);
   };
   
-  // I want: always open only one, and change only the message
   const confirm = open ? 'simple-popover' : null;
   
   const updateAvrRating = () => {
@@ -85,6 +84,7 @@ function AppDetailHook(props) {
     deleteApp(appId)
       .then(() => {
         alert(`You successfully deleted ${app.name}.`);
+        props.history.push('/');
       })
       .catch((error) => {
         alert(error.message);
@@ -94,7 +94,6 @@ function AppDetailHook(props) {
   // if there's a need to change only on frontend, you shoud not mutate an object in "state",
   // instead: make a copy, modify copy, and replace original object with copy
 
- 
   // add app to wish list
   const addToWishList = () => {
     
@@ -129,7 +128,6 @@ function AppDetailHook(props) {
           <button type="button" value={1} onClick={submitRating}>
             1 ✦
           </button>
-          
           <button type="button" value={2} onClick={submitRating}>
             2 ✦ ✦
           </button>
@@ -151,17 +149,18 @@ function AppDetailHook(props) {
 
   const wishListBtn = (
     <div>
-        <button type="button" key={props.user._id} onClick={addToWishList} className="small">
-          + &nbsp; Wish list
-         
+        <button type="button" key={props.user._id} onClick={addToWishList} className="small" >
+          {/* Wish list  */}
+          &#9825;
         </button>
   </div>
   );
 
   const removeWishListBtn = (
     <div>
-        <button type="button" key={props.user._id} onClick={removeFromWishList} className="small">
-          Saved
+        <button type="button" key={props.user._id} onClick={removeFromWishList} className="small" >
+          {/* Saved  */}
+          &#9829;
         </button>
     </div>
   );
@@ -172,7 +171,7 @@ function AppDetailHook(props) {
 
   const editLinkBtn = (
     <Link to={`/apps/edit/${appId}`} className="small" id="linkBtn">
-      <span style={{ fontWeight: '800' }} id="linkBtn">&#10000; &nbsp; &nbsp; Edit</span>
+      <span style={{ fontWeight: '500', fontSize:'21px' }} id="linkBtn">&#10000; </span>
     </Link>
   );
 

--- a/client/src/components/AppDetail.js
+++ b/client/src/components/AppDetail.js
@@ -8,12 +8,37 @@ import appIconPlaceholder from '../app-icon-placeholder.svg';
 import TextArea from './TextArea';
 import Loader from './Loader';
 // import Loader from './Loader_copy';
+// import Modal from './components/popupModal';
+import { makeStyles } from '@material-ui/core/styles';
+import Popover from '@material-ui/core/Popover';
+import Typography from '@material-ui/core/Typography';
+import Button from '@material-ui/core/Button';
 
 import './AppDetail.scss';
+import { CloudStorageIcon } from '../images';
 
 function AppDetailHook(props) {
   const [app, setApp] = useState(null);
   const [avrRating, setAvrRating] = useState(0);
+  //
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [open, setOpen] = useState(false);
+  const useStyles = makeStyles((theme) => ({
+    typography: {
+      padding: theme.spacing(2),
+      color: '#c5b79f',
+      backgroundColor: '#31708f',
+      boxShadow: "10px 10px 5px 0px  rgba(26, 24, 41, 0.7)",
+    },
+    // root: {
+    //   "& .MuiPaper-root": {
+        
+    //   }
+    // }
+  }));
+
+  const classes = useStyles();
+
 
   const appId = props.match.params.id;
   const userId = props.user._id;
@@ -43,16 +68,23 @@ function AppDetailHook(props) {
 
   const submitRating = (event) => {
     const ratingValue = event.target.value;
-
+    
     rateApp(ratingValue, appId)
       .then(() => {
-        alert(`Thank you for rating ${app.name}.`);
+        alert(`Thank you for rating ${app.name}.`); // replace it with a modal module
+        
         updateAvrRating(appId);
       })
       .catch((error) => {
         alert(error.message);
       });
   };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const id = open ? 'simple-popover' : null;
 
   const updateAvrRating = () => {
     getAverageRating(appId)
@@ -78,12 +110,14 @@ function AppDetailHook(props) {
   // if there's a need to change only on frontend, you shoud not mutate an object in "state",
   // instead: make a copy, modify copy, and replace original object with copy
 
+ 
   // add app to wish list
   const addToWishList = () => {
+    
     addWishApp(appId, userId)
       .then(() => {
-        alert(`${app.name} is added to wish list!`);
         updateAppDetails();
+        setOpen(true);
       })
       .catch((error) => {
         alert(error.message);
@@ -91,11 +125,11 @@ function AppDetailHook(props) {
   };
 
   // remove app from wish list
-  const removeFromWishList = () => {
+  const removeFromWishList = (event) => {
     removeWishApp(appId, userId)
       .then(() => {
-        alert(`${app.name} is removed from wish list!`);
         updateAppDetails();
+        setOpen(true);
       })
       .catch((error) => {
         alert(error.message);
@@ -127,15 +161,54 @@ function AppDetailHook(props) {
   if (!app) return <Loader />;
 
   const wishListBtn = (
+    <div>
     <button type="button" key={props.user._id} onClick={addToWishList} className="small">
       + &nbsp; Wish list
     </button>
+    <Popover
+      anchorReference="anchorPosition"
+      anchorPosition={{ top: 80,  left:500}}
+      id={id}
+      open={open}
+      onClose={handleClose}
+      anchorOrigin={{
+        vertical: 'center',
+        horizontal: 'bottom',
+      }}
+      transformOrigin={{
+        vertical: 'center',
+        horizontal: 'bottom',
+      }}
+    >
+    <Typography className={classes.typography}>{app.name} is removed from the list!</Typography>
+  </Popover>
+  </div>
   );
 
   const removeWishListBtn = (
-    <button type="button" key={props.user._id} onClick={removeFromWishList} className="small">
-      Saved
-    </button>
+    <div>
+      <button type="button" key={props.user._id} onClick={removeFromWishList} className="small">
+        Saved
+      </button>
+      <Popover
+      anchorReference="anchorPosition"
+      anchorPosition={{ top: 80, left:500 }}
+      id={id}
+      open={open}
+      onClose={handleClose}
+      anchorOrigin={{
+        vertical: 'center',
+        horizontal: 'bottom',
+      }}
+      transformOrigin={{
+        vertical: 'center',
+        horizontal: 'bottom',
+      }}
+    >
+      
+    <Typography className={classes.typography}>{app.name} is saved to the list!</Typography>
+    </Popover>
+  </div>
   );
 
   const wishListBtns = (
@@ -216,7 +289,8 @@ function AppDetailHook(props) {
       </div>
 
       <div className="labels-container">
-        {props.user ? wishListBtns : null}
+        {/* {props.user ? wishListBtns : null} */}
+        {wishListBtns}
         {props.user ? editLinkBtn : null}
       </div>
 

--- a/client/src/components/AppDetail.js
+++ b/client/src/components/AppDetail.js
@@ -10,17 +10,16 @@ import Loader from './Loader';
 
 import PopupModal from './PopupModal';
 
-
 import './AppDetail.scss';
-//import { CloudStorageIcon } from '../images';
+// import { CloudStorageIcon } from '../images';
 
 function AppDetailHook(props) {
   const [app, setApp] = useState(null);
   const [avrRating, setAvrRating] = useState(0);
-  // popover 
+  // popover
   const [open, setOpen] = useState(false);
   const [openMsg, setOpenMsg] = useState(null);
- 
+
   const appId = props.match.params.id;
   const userId = props.user._id;
 
@@ -47,9 +46,16 @@ function AppDetailHook(props) {
       });
   };
 
+  // popover logics
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const confirm = open ? 'simple-popover' : null;
+
   const submitRating = (event) => {
     const ratingValue = event.target.value;
-    
+
     rateApp(ratingValue, appId)
       .then(() => {
         updateAvrRating(appId);
@@ -62,13 +68,6 @@ function AppDetailHook(props) {
       });
   };
 
-  // popover logics
-  const handleClose = () => {
-    setOpen(false);
-  };
-  
-  const confirm = open ? 'simple-popover' : null;
-  
   const updateAvrRating = () => {
     getAverageRating(appId)
       .then((averageRating) => {
@@ -96,10 +95,9 @@ function AppDetailHook(props) {
 
   // add app to wish list
   const addToWishList = () => {
-    
     addWishApp(appId, userId)
       .then(() => {
-        updateAppDetails(); 
+        updateAppDetails();
         setOpenMsg(`${app.name} is added to wish list!`);
         setOpen(true);
       })
@@ -125,21 +123,21 @@ function AppDetailHook(props) {
     <div id="rateApp">
       <h4>Rate this app</h4>
       <div>
-          <button type="button" value={1} onClick={submitRating}>
-            1 ✦
-          </button>
-          <button type="button" value={2} onClick={submitRating}>
-            2 ✦ ✦
-          </button>
-            <button type="button" value={3} onClick={submitRating}>
-            3 ✦ ✦ ✦
-          </button>
-          <button type="button" value={4} onClick={submitRating}>
-            4 ✦ ✦ ✦ ✦
-          </button>
-          <button type="button" value={5} onClick={submitRating}>
-            5 ✦ ✦ ✦ ✦ ✦
-          </button>
+        <button type="button" value={1} onClick={submitRating}>
+          1 ✦
+        </button>
+        <button type="button" value={2} onClick={submitRating}>
+          2 ✦ ✦
+        </button>
+        <button type="button" value={3} onClick={submitRating}>
+          3 ✦ ✦ ✦
+        </button>
+        <button type="button" value={4} onClick={submitRating}>
+          4 ✦ ✦ ✦ ✦
+        </button>
+        <button type="button" value={5} onClick={submitRating}>
+          5 ✦ ✦ ✦ ✦ ✦
+        </button>
       </div>
     </div>
   );
@@ -149,19 +147,19 @@ function AppDetailHook(props) {
 
   const wishListBtn = (
     <div>
-        <button type="button" key={props.user._id} onClick={addToWishList} className="small" >
-          {/* Wish list  */}
-          &#9825;
-        </button>
-  </div>
+      <button type="button" key={props.user._id} onClick={addToWishList} className="small">
+        {/* + Wish list  */}
+        &#9825;
+      </button>
+    </div>
   );
 
   const removeWishListBtn = (
     <div>
-        <button type="button" key={props.user._id} onClick={removeFromWishList} className="small" >
-          {/* Saved  */}
-          &#9829;
-        </button>
+      <button type="button" key={props.user._id} onClick={removeFromWishList} className="small">
+        {/* Saved  */}
+        &#9829;
+      </button>
     </div>
   );
 
@@ -171,7 +169,7 @@ function AppDetailHook(props) {
 
   const editLinkBtn = (
     <Link to={`/apps/edit/${appId}`} className="small" id="linkBtn">
-      <span style={{ fontWeight: '500', fontSize:'21px' }} id="linkBtn">&#10000; </span>
+      <span id="linkBtn">&#10000; </span>
     </Link>
   );
 
@@ -219,12 +217,12 @@ function AppDetailHook(props) {
 
   return (
     <main id="appDetail">
-      <PopupModal 
-        id= {confirm}
-        open = {open}
-        handleClose = {handleClose}
-        message = {openMsg}
-        />
+      <PopupModal
+        id={confirm}
+        open={open}
+        handleClose={handleClose}
+        message={openMsg}
+      />
       <div className="appIntro">
         {/* <Loader /> */}
         <div className="appInfo">

--- a/client/src/components/AppDetail.js
+++ b/client/src/components/AppDetail.js
@@ -8,11 +8,10 @@ import appIconPlaceholder from '../app-icon-placeholder.svg';
 import TextArea from './TextArea';
 import Loader from './Loader';
 // import Loader from './Loader_copy';
-// import Modal from './components/popupModal';
+import PopupModal from './PopupModal';
 import { makeStyles } from '@material-ui/core/styles';
 import Popover from '@material-ui/core/Popover';
 import Typography from '@material-ui/core/Typography';
-import Button from '@material-ui/core/Button';
 
 import './AppDetail.scss';
 import { CloudStorageIcon } from '../images';
@@ -21,7 +20,7 @@ function AppDetailHook(props) {
   const [app, setApp] = useState(null);
   const [avrRating, setAvrRating] = useState(0);
   //
-  const [anchorEl, setAnchorEl] = useState(null);
+  // const [anchorEl, setAnchorEl] = useState(null);
   const [open, setOpen] = useState(false);
   const useStyles = makeStyles((theme) => ({
     typography: {
@@ -165,23 +164,14 @@ function AppDetailHook(props) {
     <button type="button" key={props.user._id} onClick={addToWishList} className="small">
       + &nbsp; Wish list
     </button>
-    <Popover
-      anchorReference="anchorPosition"
-      anchorPosition={{ top: 80,  left:500}}
-      id={id}
-      open={open}
-      onClose={handleClose}
-      anchorOrigin={{
-        vertical: 'center',
-        horizontal: 'bottom',
-      }}
-      transformOrigin={{
-        vertical: 'center',
-        horizontal: 'bottom',
-      }}
-    >
-    <Typography className={classes.typography}>{app.name} is removed from the list!</Typography>
-  </Popover>
+    <PopupModal
+     id= {id}
+     open = {open}
+     handleClose = {handleClose}
+     wishListMessage = {`${app.name} is removed from the wish list!`}
+    />
+
+   
   </div>
   );
 
@@ -190,24 +180,12 @@ function AppDetailHook(props) {
       <button type="button" key={props.user._id} onClick={removeFromWishList} className="small">
         Saved
       </button>
-      <Popover
-      anchorReference="anchorPosition"
-      anchorPosition={{ top: 80, left:500 }}
-      id={id}
-      open={open}
-      onClose={handleClose}
-      anchorOrigin={{
-        vertical: 'center',
-        horizontal: 'bottom',
-      }}
-      transformOrigin={{
-        vertical: 'center',
-        horizontal: 'bottom',
-      }}
-    >
-      
-    <Typography className={classes.typography}>{app.name} is saved to the list!</Typography>
-    </Popover>
+    <PopupModal
+     id= {id}
+     open = {open}
+     handleClose = {handleClose}
+     wishListMessage = {`${app.name} is saved to the wish list!`}
+    />
   </div>
   );
 

--- a/client/src/components/AppDetail.scss
+++ b/client/src/components/AppDetail.scss
@@ -114,11 +114,12 @@ main#appDetail {
 }
 
 #rateApp {
-  margin-top: 48px;
+  margin-top: 24px;
 }
 
 #rateApp button:not(:last-child) {
   margin-right: 16px;
+  margin-bottom: 12px;
 }
 
 .notes {

--- a/client/src/components/Button.scss
+++ b/client/src/components/Button.scss
@@ -46,7 +46,11 @@ form button {
     font-family: inherit;
   }
 
-  
+
+#linkBtn {
+    font-size: 21px;
+  }
+
 // override general a:hover style for aButton
 // a:hover #linkBtn {
 //   color: $gold;

--- a/client/src/components/Button.scss
+++ b/client/src/components/Button.scss
@@ -36,19 +36,18 @@ form button {
 
 .small {
     align-items: center;
-    width: 160px;
+    width: 60px;
     padding: 10px 20px;
     margin-bottom: 0;
+    margin-left: 0.3rem;
     font-size: 16px;
-    font-weight: 500;
-    color: $whitePink;
-    border: 1px solid $whitePink;
+    color: $bodyGreen;
+    border: 1px solid $bodyGreen;
     font-family: inherit;
   }
+
   
-// override general a:hover style
-a:hover #linkBtn {
-  color: $whitePink;
-  font-size: 16px;
-  font-weight: 500;
-}
+// override general a:hover style for aButton
+// a:hover #linkBtn {
+//   color: $gold;
+// }

--- a/client/src/components/Colors.scss
+++ b/client/src/components/Colors.scss
@@ -2,6 +2,7 @@ $darkBlue: #2b2d42;
 $darkerBlue: #232536;
 $almostWhite: #edf2f4;
 $bodyGreen: #16db86;
+$thinBodyGreen: rgba(22,219,135,0.5);
 $gray: #7485a3;
 $lightGray:#a1afc7;
 $boxShadow: rgba(26, 24, 41, 0.7);
@@ -17,3 +18,4 @@ $headsupBackgroundBlue: #d9edf7;
 $washedOutRed: #c87b7f;
 $gold: #a18d6c;
 $lightGold: #c5b79f;
+$thinlightGold: rgba(196,183,159,0.3)

--- a/client/src/components/PopupModal.js
+++ b/client/src/components/PopupModal.js
@@ -4,26 +4,26 @@ import Typography from '@material-ui/core/Typography';
 import './PopupModal.scss'
 
 export default function PopupModal(props) {
-
+    
   return (
     <div>
       <Popover
         anchorReference="anchorPosition"
-        anchorPosition={{ top: 80,  left:500}}
+        anchorPosition={{ top: 80,  left:550 }}
         id={props.id}
         open={props.open}
         onClose={props.handleClose}
-        anchorOrigin={{
-            vertical: 'center',
-            horizontal: 'bottom',
-          }}
-          transformOrigin={{
-            vertical: 'center',
-            horizontal: 'bottom',
-          }}
+        // anchorOrigin={{
+        //     vertical: 'center',
+        //     horizontal: 'top',
+        //     }}
+        // transformOrigin={{
+        //     vertical: 'center',
+        //     horizontal: 'top',
+        // }}
       >
          <Typography className='typography'>
-             {props.wishListMessage}
+             {props.message}
         </Typography>
       </Popover>
     </div>

--- a/client/src/components/PopupModal.js
+++ b/client/src/components/PopupModal.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import Popover from '@material-ui/core/Popover';
+import Typography from '@material-ui/core/Typography';
+import './PopupModal.scss'
+
+export default function PopupModal(props) {
+
+  return (
+    <div>
+      <Popover
+        anchorReference="anchorPosition"
+        anchorPosition={{ top: 80,  left:500}}
+        id={props.id}
+        open={props.open}
+        onClose={props.handleClose}
+        anchorOrigin={{
+            vertical: 'center',
+            horizontal: 'bottom',
+          }}
+          transformOrigin={{
+            vertical: 'center',
+            horizontal: 'bottom',
+          }}
+      >
+         <Typography className='typography'>
+             {props.wishListMessage}
+        </Typography>
+      </Popover>
+    </div>
+  );
+}
+
+

--- a/client/src/components/PopupModal.js
+++ b/client/src/components/PopupModal.js
@@ -1,15 +1,14 @@
 import React from 'react';
 import Popover from '@material-ui/core/Popover';
 import Typography from '@material-ui/core/Typography';
-import './PopupModal.scss'
+import './PopupModal.scss';
 
 export default function PopupModal(props) {
-    
   return (
     <div>
       <Popover
         anchorReference="anchorPosition"
-        anchorPosition={{ top: 80,  left:550 }}
+        anchorPosition={{ top: 80, left: 550 }}
         id={props.id}
         open={props.open}
         onClose={props.handleClose}
@@ -22,12 +21,10 @@ export default function PopupModal(props) {
         //     horizontal: 'top',
         // }}
       >
-         <Typography className='typography'>
-             {props.message}
+        <Typography className="typography">
+          {props.message}
         </Typography>
       </Popover>
     </div>
   );
 }
-
-

--- a/client/src/components/PopupModal.scss
+++ b/client/src/components/PopupModal.scss
@@ -1,0 +1,11 @@
+@import './Colors.scss';
+
+.typography {
+    padding: 12px;
+    color: $lightGold;
+    background-color: $headsupBlue;
+    box-shadow: 10px 10px 5px 0px  $boxShadow;
+};
+
+
+  

--- a/client/src/components/TextArea.js
+++ b/client/src/components/TextArea.js
@@ -2,9 +2,14 @@ import React, { useState, useEffect } from 'react';
 import { addReview, fetchReviews } from '../services/review';
 import './TextArea.scss';
 
+import PopupModal from './PopupModal';
+
 const TextArea = (props) => {
   const [reviewInput, setReviewInput] = useState('');
   const [reviews, setReviews] = useState([]);
+  const [open, setOpen] = useState(false);
+  const [openMsg, setOpenMsg] = useState(null);
+
   const appId = props.app._id;
   const { userId } = props;
 
@@ -12,6 +17,7 @@ const TextArea = (props) => {
     fetchReviews(appId)
       .then((reviewsOfApp) => {
         setReviews(reviewsOfApp);
+        
       })
       .catch((error) => {
         alert(error.message);
@@ -26,13 +32,20 @@ const TextArea = (props) => {
     setReviewInput(event.target.value);
   }
 
+  // popover 
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+const confirm = open ? 'simple-popover' : null;
   function handleSubmit(event) {
     event.preventDefault(); // stops default reloading behaviour
     // make sure take the input value in state, not event.target.value
 
     addReview(reviewInput, appId, userId)
       .then(() => {
-        alert(`Thank you for reviewing ${props.app.name}.`);
+        setOpenMsg('Thanks for sharing!');
+        setOpen(true);
 
         updateReviewsList(appId);
         setReviewInput('');
@@ -46,7 +59,13 @@ const TextArea = (props) => {
 
   return (
     <div id="rateApp">
-      <h4>Reviews</h4>
+      <PopupModal 
+        id= {confirm}
+        open = {open}
+        handleClose = {handleClose}
+        message = {openMsg}
+        />
+      <h4>Comments</h4>
       {reviews.map((review) => (
         <div key={review._id} className="reivews-container">
           <div className="review-user-container">
@@ -65,7 +84,7 @@ const TextArea = (props) => {
           placeholder="How do you like this app?"
           className="comment-text-area"
         />
-        <button type="submit" className="small-submit-btn">Submit</button>
+        <button type="submit" className="small-submit-btn">Post</button>
       </form>
     </div>
   );

--- a/client/src/components/TextArea.js
+++ b/client/src/components/TextArea.js
@@ -13,11 +13,10 @@ const TextArea = (props) => {
   const appId = props.app._id;
   const { userId } = props;
 
-  const updateReviewsList = (appId) => {
-    fetchReviews(appId)
+  const updateReviewsList = (reviewedAppId) => {
+    fetchReviews(reviewedAppId)
       .then((reviewsOfApp) => {
         setReviews(reviewsOfApp);
-        
       })
       .catch((error) => {
         alert(error.message);
@@ -32,12 +31,12 @@ const TextArea = (props) => {
     setReviewInput(event.target.value);
   }
 
-  // popover 
+  // popover
   const handleClose = () => {
     setOpen(false);
   };
 
-const confirm = open ? 'simple-popover' : null;
+  const confirm = open ? 'simple-popover' : null;
   function handleSubmit(event) {
     event.preventDefault(); // stops default reloading behaviour
     // make sure take the input value in state, not event.target.value
@@ -59,12 +58,12 @@ const confirm = open ? 'simple-popover' : null;
 
   return (
     <div id="rateApp">
-      <PopupModal 
-        id= {confirm}
-        open = {open}
-        handleClose = {handleClose}
-        message = {openMsg}
-        />
+      <PopupModal
+        id={confirm}
+        open={open}
+        handleClose={handleClose}
+        message={openMsg}
+      />
       <h4>Comments</h4>
       {reviews.map((review) => (
         <div key={review._id} className="reivews-container">

--- a/client/src/components/TextArea.scss
+++ b/client/src/components/TextArea.scss
@@ -14,7 +14,6 @@
   background-color: $darkerBlue;
   color: $almostWhite;
   border: 0;
-  margin-top: 1rem;
   margin-bottom: 16px;
   /* only differnce from #addApp textarea */
   height: 100px;
@@ -34,6 +33,7 @@
   padding: 0 16px 16px 16px;
   /* add alpha value in rgb to generate line < 1px */
   border-bottom: 1px solid $thinWhitePink;
+  border-top: 1px solid $thinWhitePink;
 }
 
 .reivews-container p{
@@ -46,9 +46,10 @@
   flex-direction: row;
   align-items: baseline;
   padding-right: 10px;
+  margin-top: 1rem;
 }
 
-.review-user-container h5 {
+.review-user-container h5  {
   padding-right: 10px
 }
 


### PR DESCRIPTION
This adds a customised popup notification module to the app, to replace the alert popup. It applies currently to the AppDetail view for button events. 

Also, Edit and Add-to-Wishlist buttons are redesigned to only symbols. 

The customised popup requires popver from material UI. 
