### PR TITLE
Display login dialog to not-log-in user

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
     'react/prop-types': 0,
     'react/destructuring-assignment': 0,
     'import/prefer-default-export': 0,
+    'object-shorthand': 0,
   },
   ignorePatterns: [
     'build/*',

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -16,6 +16,7 @@ import SideDrawer from './components/SideDrawer';
 import Backdrop from './components/Backdrop';
 
 import { SharedSnackbarProvider } from './components/SharedSnackbar.context';
+import { SharedDialogProvider } from './components/SharedDialog.context';
 
 class App extends Component {
   state = {
@@ -38,6 +39,7 @@ class App extends Component {
     this.setState({ sideDrawerOpen: false });
   }
 
+
   render() {
     // instead of write tenerary in JSX, write elegently as below
     let backdrop;
@@ -47,8 +49,9 @@ class App extends Component {
 
     return (
       <div className="App">
+        <SharedDialogProvider>
         <SharedSnackbarProvider>
-       
+        
         <header>
           <Navbar user={this.state.user} handleDrawerToggleClick={this.handleDrawerToggleClick} />
           {/* side drawer always open, add animation */}
@@ -58,8 +61,6 @@ class App extends Component {
         
         <Switch>
           <Route exact path="/" component={HomePage} />
-          {/* <Route exact path="/alternatives" component={AlternativesPage} / */}
-          
           <Route
             exact
             path="/signup"
@@ -96,7 +97,9 @@ class App extends Component {
             component={About}
           />
         </Switch>
+        
         </SharedSnackbarProvider>
+        </SharedDialogProvider>
       </div>
     );
   }

--- a/client/src/components/AppDetail.js
+++ b/client/src/components/AppDetail.js
@@ -51,18 +51,65 @@ function AppDetailHook(props) {
       });
   };
 
-  const submitRating = (event) => {
-    const ratingValue = event.target.value;
+  // check on frontend if user logs in
+  const ensureLogin = (callbackFunc) => {
+    const dialogMessage = 'Log in to continue.';
+    if (props.user) {
+      callbackFunc();
+    } else {
+      openDialog(dialogMessage);
+    }
+  };
 
+  const sendSubmitRatingRequest = (event) => {
+    const ratingValue = event.target.value;
     rateApp(ratingValue, appId)
       .then(() => {
         updateAvrRating(appId);
         updateAppDetails();
-        handlePopup(`Thank you for rating ${app.name}!`);
+        openSnackbar(`Thank you for rating ${app.name}!`);
       })
       .catch((error) => {
         alert(error.message);
       });
+  };
+
+  const submitRating = (event) => {
+    // anonymous function (()=>{}), as need to pass a parameter which is a function
+    // ensureLogin desides whenever to call sendSubmitRatingRequest
+    ensureLogin(() => sendSubmitRatingRequest(event));
+  };
+
+  const sendWishListRequest = () => {
+    addWishApp(appId, userId)
+      .then(() => {
+        updateAppDetails();
+        openSnackbar(`${app.name} is added to wish list!`);
+      })
+      .catch((error) => {
+        alert(error.message);
+      });
+  };
+
+  const addToWishList = () => {
+    // sendWishListRequest is callback passed to ensureLogin;
+    // ensureLogin call callback if props.user
+    ensureLogin(sendWishListRequest);
+  };
+
+  const sendRemoveRequest = () => {
+    removeWishApp(appId, userId)
+      .then(() => {
+        updateAppDetails();
+        openSnackbar(`${app.name} is removed from wish list!`);
+      })
+      .catch((error) => {
+        alert(error.message);
+      });
+  };
+
+  const removeFromWishList = () => {
+    ensureLogin(sendRemoveRequest);
   };
 
   const updateAvrRating = () => {
@@ -86,35 +133,8 @@ function AppDetailHook(props) {
       });
   };
 
-  // if there's a need to change only on frontend, you shoud not mutate an object in "state",
+  // if there's a need to change only on frontend, you should not mutate an object in "state",
   // instead: make a copy, modify copy, and replace original object with copy
-
-  const handlePopup = (dynamicMsg) => {
-    if (!props.user) openDialog('Log in to continue.');
-    else openSnackbar(dynamicMsg);
-  };
-
-  const addToWishList = () => {
-    addWishApp(appId, userId)
-      .then(() => {
-        updateAppDetails();
-        handlePopup(`${app.name} is added to wish list!`);
-      })
-      .catch((error) => {
-        alert(error.message);
-      });
-  };
-
-  const removeFromWishList = () => {
-    removeWishApp(appId, userId)
-      .then(() => {
-        updateAppDetails();
-        handlePopup(`${app.name} is removed from wish list!`);
-      })
-      .catch((error) => {
-        alert(error.message);
-      });
-  };
 
   const ratingBtns = (
     <div id="rateApp">

--- a/client/src/components/AppDetail.js
+++ b/client/src/components/AppDetail.js
@@ -13,6 +13,7 @@ import iconApproved from '../images/iconApproved.svg';
 import iconPencilEdit from '../images/iconPencilEdit.svg';
 
 import SharedSnackbarContext from './SharedSnackbar.context';
+import SharedDialogContext from './SharedDialog.context';
 
 import './AppDetail.scss';
 // import { CloudStorageIcon } from '../images';
@@ -22,6 +23,7 @@ function AppDetailHook(props) {
   const [avrRating, setAvrRating] = useState(0);
 
   const { openSnackbar } = useContext(SharedSnackbarContext);
+  const { openDialog } = useContext(SharedDialogContext);
 
   const appId = props.match.params.id;
   const userId = props.user._id;
@@ -56,7 +58,7 @@ function AppDetailHook(props) {
       .then(() => {
         updateAvrRating(appId);
         updateAppDetails();
-        openSnackbar(`Thank you for rating ${app.name}!`);
+        handlePopup(`Thank you for rating ${app.name}!`);
       })
       .catch((error) => {
         alert(error.message);
@@ -73,7 +75,6 @@ function AppDetailHook(props) {
       });
   };
 
-  // delete app
   const deleteOneApp = () => {
     deleteApp(appId)
       .then(() => {
@@ -88,24 +89,27 @@ function AppDetailHook(props) {
   // if there's a need to change only on frontend, you shoud not mutate an object in "state",
   // instead: make a copy, modify copy, and replace original object with copy
 
-  // add app to wish list
+  const handlePopup = (dynamicMsg) => {
+    if (!props.user) openDialog('Log in to continue.');
+    else openSnackbar(dynamicMsg);
+  };
+
   const addToWishList = () => {
     addWishApp(appId, userId)
       .then(() => {
         updateAppDetails();
-        openSnackbar(`${app.name} is added to wish list!`);
+        handlePopup(`${app.name} is added to wish list!`);
       })
       .catch((error) => {
         alert(error.message);
       });
   };
 
-  // remove app from wish list
   const removeFromWishList = () => {
     removeWishApp(appId, userId)
       .then(() => {
         updateAppDetails();
-        openSnackbar(`${app.name} is removed from wish list!`);
+        handlePopup(`${app.name} is removed from wish list!`);
       })
       .catch((error) => {
         alert(error.message);
@@ -189,7 +193,7 @@ function AppDetailHook(props) {
   }
 
   let lastEditUser;
-  if (app.editors.length < 1) {
+  if (app.editors.length < 1 || app.editors[app.editors.length - 1].username == null) {
     lastEditUser = null;
   } else {
     lastEditUser = (
@@ -204,14 +208,8 @@ function AppDetailHook(props) {
 
   return (
     <main id="appDetail">
-      {/* <PopupModal
-        id={confirm}
-        open={open}
-        handleClose={handleClose}
-        message={openMsg}
-      /> */}
+
       <div className="appIntro">
-        {/* <Loader /> */}
         <div className="appInfo">
           <img src={app.logo || appIconPlaceholder} alt="" />
           <div>
@@ -234,19 +232,18 @@ function AppDetailHook(props) {
       </div>
 
       <div className="labels-container">
-        {props.user ? wishListBtns : null}
-        {props.user ? editLinkBtn : null}
+        {wishListBtns}
+        {editLinkBtn}
       </div>
 
       <div className="description">
         <h3>Description</h3>
         <p>{app.description}</p>
-
         <div>
           <h4>Available devices:</h4>
           <ul>{app.device && app.device.map((device, index) => <li key={index}>{device}</li>)}</ul>
         </div>
-        {props.user ? ratingBtns : null}
+        {ratingBtns}
         <TextArea userId={userId} app={app} />
         {deleteBtn}
       </div>
@@ -254,7 +251,6 @@ function AppDetailHook(props) {
         {creatorUser}
         {lastEditUser}
       </div>
-
     </main>
   );
 }

--- a/client/src/components/Colors.scss
+++ b/client/src/components/Colors.scss
@@ -11,7 +11,8 @@ $thinWhitePink: rgba(174,168,211, 0.5);
 $paleWhitePink: #cecae4ff;
 $backDropBlack: rgba(0, 0, 0, 0.3);
 
-$successGreenGradient: linear-gradient(to right,#097968, #097957 );; 
+$successGreenGradient: linear-gradient(to right, #1E7B1E, #28A428, #008081);
+$headsupBlueGradient: linear-gradient(to right, #6699CD, #618DB8, #5D81A3, #58748D, #536878);
 $errorRed: #ff3c46;
 $headsupBlue: #31708f;
 $headsupLightBlue: #bce8f1;

--- a/client/src/components/EditApp.js
+++ b/client/src/components/EditApp.js
@@ -4,6 +4,7 @@ import { fetchAllCategories } from '../services/category';
 import Loader from './Loader';
 
 import SharedSnackbarContext from './SharedSnackbar.context';
+import SharedDialogContext from './SharedDialog.context';
 
 import './NewApp.scss';
 
@@ -17,6 +18,7 @@ function EditApp(props) {
   const [logo, setLogo] = useState('');
 
   const { openSnackbar } = useContext(SharedSnackbarContext);
+  const { openDialog } = useContext(SharedDialogContext);
 
   const appId = props.match.params.id;
 
@@ -75,12 +77,10 @@ function EditApp(props) {
         deviceCopy.splice(index, 1);
       }
     }
-
     setDevice(deviceCopy);
   }
 
-  function handleEditSubmit(event) {
-    event.preventDefault();
+  function handleEditSubmit() {
     const editor = props.user._id;
     editApp(appId, name, description, category, device, website, logo, editor)
       .then((editedApp) => {
@@ -91,6 +91,14 @@ function EditApp(props) {
         alert(error.message);
       });
   }
+
+  const handleEditPermission = (event) => {
+    // prevent brwoser default sends http form request (only send from JS)
+    event.preventDefault(); 
+
+    if (!props.user) openDialog('Log in to continue.');
+    else handleEditSubmit();
+  };
 
   if (!categories) return <Loader />;
   const categoryOptions = categories.map((selectedCategory) => (
@@ -104,7 +112,7 @@ function EditApp(props) {
 
   return (
     <main>
-      <form onSubmit={handleEditSubmit} id="addApp">
+      <form onSubmit={handleEditPermission} id="addApp">
         <h2>Edit app</h2>
         <div>
           <label htmlFor="name">

--- a/client/src/components/EditApp.js
+++ b/client/src/components/EditApp.js
@@ -94,7 +94,7 @@ function EditApp(props) {
 
   const handleEditPermission = (event) => {
     // prevent brwoser default sends http form request (only send from JS)
-    event.preventDefault(); 
+    event.preventDefault();
 
     if (!props.user) openDialog('Log in to continue.');
     else handleEditSubmit();

--- a/client/src/components/NewApp.js
+++ b/client/src/components/NewApp.js
@@ -72,7 +72,7 @@ function NewApp(props) {
     createApp(name, description, category, device, website, logo, creator)
       .then((app) => {
         props.history.push(`/apps/${app._id}`);
-        openSnackbar(`${app.name} is published. Thanks for your contribution!`)
+        openSnackbar(`${app.name} is published. Thanks for your contribution!`);
       })
       .catch((error) => {
         alert(error.message);

--- a/client/src/components/SharedDialog.component.js
+++ b/client/src/components/SharedDialog.component.js
@@ -1,0 +1,34 @@
+import { Snackbar } from '@material-ui/core';
+import React from 'react';
+import { SharedDialogConsumer } from './SharedDialog.context';
+
+import './SharedDialog.scss';
+
+const SharedDialog = () => (
+  <SharedDialogConsumer>
+    {({ dialogIsOpen, dialogMessage, closeDialog }) => (
+      <Snackbar
+        className="top-message"
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'center',
+        }}
+        open={dialogIsOpen}
+        onClose={closeDialog}
+        message={dialogMessage}
+        action={[
+          <div className="dialog-aBtns">
+            <a href="/login" className="dialog-btn">
+              Log in
+            </a>
+            <button onClick={closeDialog} className="dialog-btn">
+              Not now
+            </button>
+          </div>,
+        ]}
+      />
+    )}
+  </SharedDialogConsumer>
+);
+
+export default SharedDialog;

--- a/client/src/components/SharedDialog.context.js
+++ b/client/src/components/SharedDialog.context.js
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import SharedDialog from './SharedDialog.component';
+import './SharedDialog.scss';
+
+const SharedDialogContext = React.createContext();
+
+export function SharedDialogProvider(props) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [message, setMessage] = useState('');
+
+  const openDialog = (displayMessage) => {
+    setMessage(displayMessage);
+    setIsOpen(true);
+  };
+
+  const closeDialog = () => {
+    setMessage('');
+    setIsOpen(false);
+  };
+
+  const { children } = props;
+
+  return (
+    <SharedDialogContext.Provider
+      value={{
+        openDialog: openDialog,
+        closeDialog: closeDialog,
+        dialogIsOpen: isOpen,
+        dialogMessage: message,
+      }}
+    >
+      {/* Render Snackbar presentation component here */}
+      <SharedDialog />
+      {children}
+    </SharedDialogContext.Provider>
+  );
+}
+
+export const SharedDialogConsumer = SharedDialogContext.Consumer;
+export default SharedDialogContext;

--- a/client/src/components/SharedDialog.scss
+++ b/client/src/components/SharedDialog.scss
@@ -1,0 +1,44 @@
+@import './Colors.scss';
+
+.top-message .MuiSnackbarContent-message {
+    color: $paleWhitePink;
+    font-size: 20px;
+}
+
+.top-message .MuiSnackbarContent-action {
+    display: inline-block ;
+    padding: 0px ;
+    margin: 0px ;
+}
+
+.top-message .MuiSnackbarContent-root  {
+    font-size: 18px;
+    background-image: $headsupBlueGradient;
+    display: inline-block ;
+}
+
+.top-message .dialog-aBtns {
+    display: inline-block;
+    font-size: 16px;
+    text-decoration: underline;
+}
+
+.top-message .dialog-aBtns a {
+    padding: 10px 20px;
+}
+
+.top-message .dialog-btn {
+    background-color: transparent;
+    color: $lightGold;
+    border: none;
+    text-decoration: underline;
+    font-weight: 600;
+}
+
+// apply rules if larger than 601px
+@media (min-width: 601px) {
+.top-message .MuiSnackbarContent-root {
+    flex-grow: initial;
+    min-width: 680px;
+   }
+}

--- a/client/src/components/SharedSnackBar.component.js
+++ b/client/src/components/SharedSnackBar.component.js
@@ -1,15 +1,15 @@
-import { IconButton, Snackbar } from '@material-ui/core';
-// import { Close } from '@material-ui/icons';
-import { withStyles } from '@material-ui/core/styles';
+import { Snackbar } from '@material-ui/core';
 import React from 'react';
 import { SharedSnackbarConsumer } from './SharedSnackbar.context';
 
 import './SharedSnackbar.scss';
 
 const SharedSnackbar = () => (
+
   <SharedSnackbarConsumer>
     {({ snackbarIsOpen, message, closeSnackbar }) => (
       <Snackbar
+        className="success"
         anchorOrigin={{
           vertical: 'top',
           horizontal: 'center',
@@ -18,11 +18,6 @@ const SharedSnackbar = () => (
         autoHideDuration={3000}
         onClose={closeSnackbar}
         message={message}
-        // action={[
-        //   <IconButton key="close" color="inherit" onClick={closeSnackbar}>
-        //     <Close />
-        //   </IconButton>,
-        // ]}
       />
     )}
   </SharedSnackbarConsumer>

--- a/client/src/components/SharedSnackbar.scss
+++ b/client/src/components/SharedSnackbar.scss
@@ -1,14 +1,20 @@
 @import './Colors.scss';
 
-.MuiSnackbarContent-message {
+.success .MuiSnackbarContent-message {
     color: $lightGold;
     font-size: 16px;
 }
 
-.MuiSnackbarContent-root {
-    background-color: $bodyGreen !important;
+.success .MuiSnackbarContent-root {
     background-image: $successGreenGradient;
-    box-shadow: 10px 10px 5px 0px  $boxShadow !important;
-    display: block !important;
+    box-shadow: 10px 10px 5px 0px  $boxShadow ;
+    display: block ;
 }
+
+@media (min-width: 601px) {
+    .success .MuiSnackbarContent-root {
+        flex-grow: initial;
+        min-width: 340px;
+       }
+    }
 

--- a/client/src/components/TextArea.js
+++ b/client/src/components/TextArea.js
@@ -42,15 +42,17 @@ const TextArea = (props) => {
   // };
   // const confirm = open ? 'simple-popover' : null;
 
-  const handlePopup = (dynamicMsg) => {
-    if (!props.userId) openDialog('Log in to share your thoughts.');
-    else openSnackbar(dynamicMsg);
+  const ensureLogin = (callbackFunc) => {
+    const dialogMessage = 'Log in to continue.';
+    if (props.userId) {
+      callbackFunc();
+    } else {
+      openDialog(dialogMessage);
+    }
   };
 
-  function handleSubmit(event) {
-    event.preventDefault(); // stops default reloading behaviour
+  const sendReviewRequest = () => {
     // make sure take the input value in state, not event.target.value
-
     addReview(reviewInput, appId, userId)
       .then(() => {
         // setOpenMsg('Thanks for sharing!');
@@ -58,12 +60,17 @@ const TextArea = (props) => {
         // openSnackbar('Thanks for sharing your thoughts!');
         updateReviewsList(appId);
         setReviewInput('');
-        handlePopup('Thanks for sharing your thoughts!');
+        openSnackbar('Thanks for sharing your thoughts!');
       })
       .catch((error) => {
         alert(error.message);
       });
-  }
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    ensureLogin(sendReviewRequest);
+  };
 
   const timeStampDates = (timeStamp) => timeStamp.slice(0, 10);
 

--- a/client/src/components/TextArea.js
+++ b/client/src/components/TextArea.js
@@ -4,6 +4,7 @@ import './TextArea.scss';
 
 // import PopupModal from './PopupModal';
 import SharedSnackbarContext from './SharedSnackbar.context';
+import SharedDialogContext from './SharedDialog.context';
 
 const TextArea = (props) => {
   const [reviewInput, setReviewInput] = useState('');
@@ -15,6 +16,7 @@ const TextArea = (props) => {
   const { userId } = props;
 
   const { openSnackbar } = useContext(SharedSnackbarContext);
+  const { openDialog } = useContext(SharedDialogContext);
 
   const updateReviewsList = (reviewedAppId) => {
     fetchReviews(reviewedAppId)
@@ -40,6 +42,11 @@ const TextArea = (props) => {
   // };
   // const confirm = open ? 'simple-popover' : null;
 
+  const handlePopup = (dynamicMsg) => {
+    if (!props.userId) openDialog('Log in to share your thoughts.');
+    else openSnackbar(dynamicMsg);
+  };
+
   function handleSubmit(event) {
     event.preventDefault(); // stops default reloading behaviour
     // make sure take the input value in state, not event.target.value
@@ -48,9 +55,10 @@ const TextArea = (props) => {
       .then(() => {
         // setOpenMsg('Thanks for sharing!');
         // setOpen(true);
-        openSnackbar('Thanks for sharing your thoughts!');
+        // openSnackbar('Thanks for sharing your thoughts!');
         updateReviewsList(appId);
         setReviewInput('');
+        handlePopup('Thanks for sharing your thoughts!');
       })
       .catch((error) => {
         alert(error.message);

--- a/routes/app.routes.js
+++ b/routes/app.routes.js
@@ -53,7 +53,7 @@ router.post('/', ensureLogin.ensureLoggedIn(), (req, res) => {
 });
 
 // edit an app
-router.patch('/:id', (req, res) => {
+router.patch('/:id', ensureLogin.ensureLoggedIn(), (req, res) => {
   // appToBeEdit in editApp is sent as req.body in app.js
   const appToBeEdit = req.body;
   const editorId = req.body.editor;
@@ -89,10 +89,10 @@ router.delete('/:id', (req, res) => {
 });
 
 // add app to wish list
-router.post('/user/:userId', (req, res) => {
+router.post('/user/:userId', ensureLogin.ensureLoggedIn(), (req, res) => {
   const wishAppId = req.body.appId;
   const wishUserId = req.body.userId;
-
+  // if wishUserId is null, do nothing
   App
     .findByIdAndUpdate(
       wishAppId,
@@ -107,7 +107,7 @@ router.post('/user/:userId', (req, res) => {
 });
 
 // remove app from wish list
-router.patch('/user/:userId', (req, res) => {
+router.patch('/user/:userId', ensureLogin.ensureLoggedIn(), (req, res) => {
   const wishAppId = req.body.appId;
   const wishUserId = req.body.userId;
 


### PR DESCRIPTION
This pr adds a global dialog modal. User that are not logged-in can see all buttons, but will see the popup dialog asking them to sign in to conitue their actions in stead of success snackbar messages. 

- Dialog modal (useContext) let users choose to be redirect to signin page or do nothing.
- Checking user logged-in status is set up in both frontend and backend. 
- Stying is added based on notification types (success-green snackbar and headsup-blue to dialog). 



