### PR TITLE
Unlock navbar and side drawer items to all users

### DIFF
--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -31,9 +31,9 @@ const Navbar = (props) => {
         Log in
       </Link>
     )
-  )
+  );
 
-  const wishListAButton =  (
+  const wishListAButton = (
     props.user ? (
       <Link to={`/apps/wishlist/${props.user._id}`} className="nav-bar-texts">
         Wish list
@@ -41,7 +41,7 @@ const Navbar = (props) => {
     ) : (
       <button className="nav-bar-texts button-link" onClick={() => openDialog('Log in to create a wish list.')}>
         Wish list
-     </button>
+      </button>
     )
   );
 
@@ -52,49 +52,49 @@ const Navbar = (props) => {
         {' '}
         {props.user.username}
       </p>
-       <Link to="/about" className="nav-bar-texts">
-       About
-     </Link>
-     <Link to="/apps/new" className="nav-bar-texts">
-       <span>＋</span>
-       {' '}
-       Add app
-     </Link>
+      <Link to="/about" className="nav-bar-texts">
+        About
+      </Link>
+      <Link to="/apps/new" className="nav-bar-texts">
+        <span>＋</span>
+        {' '}
+        Add app
+      </Link>
       {wishListAButton}
       {logInlogOutBtn}
-     </div>
-  )
+    </div>
+  );
 
   const logoutContent = (
-    <div className='logout-content'>
-        <div className="loggedUser">
-          <Link to="/about" className="nav-bar-texts">
+    <div className="logout-content">
+      <div className="loggedUser">
+        <Link to="/about" className="nav-bar-texts">
           About
-          </Link>
-          <Link to="/apps/new" className="nav-bar-texts">
+        </Link>
+        <Link to="/apps/new" className="nav-bar-texts">
           <span>＋</span>
           {' '}
           Add app
-          </Link>
-          {wishListAButton}
-        </div>
-        {logInlogOutBtn}
-    </div>
-  )
-      
-  const drawerToggleBtn = (
-      <div className="navbar-toggle-btn">
-        <DrawerToggleBtn click={props.handleDrawerToggleClick} />
+        </Link>
+        {wishListAButton}
       </div>
+      {logInlogOutBtn}
+    </div>
+  );
+
+  const drawerToggleBtn = (
+    <div className="navbar-toggle-btn">
+      <DrawerToggleBtn click={props.handleDrawerToggleClick} />
+    </div>
   );
 
   return (
     <nav className="navbar">
       {drawerToggleBtn}
       <div id="logoHome">
-          <Link to="/">
-            <img src="https://res.cloudinary.com/dt9v4wqeu/image/upload/v1590001345/openstock/logoOpenstock.svg" alt="" />
-          </Link>
+        <Link to="/">
+          <img src="https://res.cloudinary.com/dt9v4wqeu/image/upload/v1590001345/openstock/logoOpenstock.svg" alt="" />
+        </Link>
       </div>
       {props.user ? loginContent : logoutContent}
     </nav>

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -4,11 +4,13 @@ import { logout } from '../services/auth';
 
 import DrawerToggleBtn from './DrawerToggleBtn';
 import SharedSnackbarContext from './SharedSnackbar.context';
+import SharedDialogContext from './SharedDialog.context';
 
 import './Navbar.scss';
 
 const Navbar = (props) => {
   const { openSnackbar } = useContext(SharedSnackbarContext);
+  const { openDialog } = useContext(SharedDialogContext);
   // window.location redirects user back to homepage and reload the page
   const handleLogOut = () => {
     logout()
@@ -21,57 +23,80 @@ const Navbar = (props) => {
       });
   };
 
-  const loggedInContent = (
-    props.user && (
-    <div className="loggedUser">
-      <p>
-        Hi
-        {' '}
-        <b>{props.user.username}</b>
-      </p>
-      <Link to="/about" className="nav-bar-texts">
-        About
+  const logInlogOutBtn = (
+    props.user ? (
+      <button onClick={handleLogOut}>Log out</button>
+    ) : (
+      <Link to="/login" className="aButton nav-bar-texts">
+        Log in
       </Link>
-      <Link to="/apps/new" className="nav-bar-texts">
-        <span>＋</span>
-        {' '}
-        Add app
-      </Link>
+    )
+  )
+
+  const wishListAButton =  (
+    props.user ? (
       <Link to={`/apps/wishlist/${props.user._id}`} className="nav-bar-texts">
         Wish list
       </Link>
-      <button onClick={handleLogOut}>Log out</button>
-    </div>
+    ) : (
+      <button className="nav-bar-texts button-link" onClick={() => openDialog('Log in to create a wish list.')}>
+        Wish list
+     </button>
     )
   );
 
-  const loggedOutContent = (
-    <div>
-      <Link to="/login" className="aButton">
-        Log in
-      </Link>
-    </div>
-  );
+  const loginContent = (
+    <div className="loggedUser">
+      <p>
+        Hi,
+        {' '}
+        {props.user.username}
+      </p>
+       <Link to="/about" className="nav-bar-texts">
+       About
+     </Link>
+     <Link to="/apps/new" className="nav-bar-texts">
+       <span>＋</span>
+       {' '}
+       Add app
+     </Link>
+      {wishListAButton}
+      {logInlogOutBtn}
+     </div>
+  )
 
+  const logoutContent = (
+    <div className='logout-content'>
+        <div className="loggedUser">
+          <Link to="/about" className="nav-bar-texts">
+          About
+          </Link>
+          <Link to="/apps/new" className="nav-bar-texts">
+          <span>＋</span>
+          {' '}
+          Add app
+          </Link>
+          {wishListAButton}
+        </div>
+        {logInlogOutBtn}
+    </div>
+  )
+      
   const drawerToggleBtn = (
-    props.user
-      && (
       <div className="navbar-toggle-btn">
         <DrawerToggleBtn click={props.handleDrawerToggleClick} />
       </div>
-      )
   );
 
   return (
     <nav className="navbar">
       {drawerToggleBtn}
       <div id="logoHome">
-        <Link to="/">
-          <img src="https://res.cloudinary.com/dt9v4wqeu/image/upload/v1590001345/openstock/logoOpenstock.svg" alt="" />
-        </Link>
-        {/* <Link to="/alternatives">Alternatives to</Link> */}
+          <Link to="/">
+            <img src="https://res.cloudinary.com/dt9v4wqeu/image/upload/v1590001345/openstock/logoOpenstock.svg" alt="" />
+          </Link>
       </div>
-      {props.user ? loggedInContent : loggedOutContent}
+      {props.user ? loginContent : logoutContent}
     </nav>
   );
 };

--- a/client/src/components/Navbar.scss
+++ b/client/src/components/Navbar.scss
@@ -42,6 +42,20 @@ font-weight: 300;
 color:$bodyGreen;
 }
 
+.button-link {
+appearance: none; // browser default look
+text-decoration: none;
+border: none;
+color: $almostWhite;
+padding: 0;
+font-family: 'Roboto';
+}
+
+.logout-content {
+    display: flex;
+    align-items: baseline;
+}
+
 /* hide burger btn if larger than 601px */
 @media (min-width: 601px) {
 .navbar-toggle-btn {
@@ -51,7 +65,7 @@ color:$bodyGreen;
 
 /* hide loggedUser navbar items if below 600px */
 @media (max-width: 600px) {
-.loggedUser {
+.loggedUser  {
     display: none;
 }
 }

--- a/client/src/components/NewApp.js
+++ b/client/src/components/NewApp.js
@@ -4,6 +4,7 @@ import { fetchAllCategories } from '../services/category';
 import Loader from './Loader';
 
 import SharedSnackbarContext from './SharedSnackbar.context';
+import SharedDialogContext from './SharedDialog.context';
 
 import './NewApp.scss';
 
@@ -17,6 +18,7 @@ function NewApp(props) {
   const [logo, setLogo] = useState('');
 
   const { openSnackbar } = useContext(SharedSnackbarContext);
+  const { openDialog } = useContext(SharedDialogContext);
 
   useEffect(() => {
     fetchAllCategories()
@@ -61,14 +63,15 @@ function NewApp(props) {
         deviceCopy.splice(index, 1);
       }
     }
-
     setDevice(deviceCopy);
   }
 
+  // can also be nested in ensureLogin as in EditApp
   function handleSubmit(event) {
     event.preventDefault();
     const creator = props.user._id;
 
+    if (props.user)
     createApp(name, description, category, device, website, logo, creator)
       .then((app) => {
         props.history.push(`/apps/${app._id}`);
@@ -77,6 +80,7 @@ function NewApp(props) {
       .catch((error) => {
         alert(error.message);
       });
+    else (openDialog('Log in to continue.'));
   }
 
   if (!categories) return <Loader />;

--- a/client/src/components/NewApp.js
+++ b/client/src/components/NewApp.js
@@ -71,16 +71,16 @@ function NewApp(props) {
     event.preventDefault();
     const creator = props.user._id;
 
-    if (props.user)
-    createApp(name, description, category, device, website, logo, creator)
-      .then((app) => {
-        props.history.push(`/apps/${app._id}`);
-        openSnackbar(`${app.name} is published. Thanks for your contribution!`);
-      })
-      .catch((error) => {
-        alert(error.message);
-      });
-    else (openDialog('Log in to continue.'));
+    if (props.user) {
+      createApp(name, description, category, device, website, logo, creator)
+        .then((app) => {
+          props.history.push(`/apps/${app._id}`);
+          openSnackbar(`${app.name} is published. Thanks for your contribution!`);
+        })
+        .catch((error) => {
+          alert(error.message);
+        });
+    } else (openDialog('Log in to continue.'));
   }
 
   if (!categories) return <Loader />;

--- a/client/src/components/SideDrawer.js
+++ b/client/src/components/SideDrawer.js
@@ -23,25 +23,25 @@ const SideDrawer = (props) => {
   const { openSnackbar } = useContext(SharedSnackbarContext);
   const { openDialog } = useContext(SharedDialogContext);
 
-  const wishListAButton =  (
+  const wishListAButton = (
     props.user ? (
       <a href={`/apps/wishlist/${props.user._id}`}>Wish list</a>
     ) : (
-      <button onClick={() => openDialog('Log in to create a wish list.')} className='sidebar-btn-link'>
+      <button onClick={() => openDialog('Log in to create a wish list.')} className="sidebar-btn-link">
         Wish list
-     </button>
+      </button>
     )
   );
 
   const welcomeMsg = (
     props.user && (
       <li className="user-name">
-            Hi,
-            {' '}
-            {props.user.username}
-          </li>
-    ) 
-  )
+        Hi,
+        {' '}
+        {props.user.username}
+      </li>
+    )
+  );
 
   const handleLogOut = () => {
     logout()
@@ -76,16 +76,19 @@ const SideDrawer = (props) => {
               About
             </a>
           </li>
-          {props.user ?
-            <li>
-              <button onClick={handleLogOut}>Log out</button>
-            </li> : 
-            <li>
-              <a href="/login" className='sidebar-a-btn'>
-                Log in
-              </a>
-            </li>
-          }
+          {props.user
+            ? (
+              <li>
+                <button onClick={handleLogOut}>Log out</button>
+              </li>
+            )
+            : (
+              <li>
+                <a href="/login" className="sidebar-a-btn">
+                  Log in
+                </a>
+              </li>
+            )}
         </ul>
       </nav>
       {backdrop}

--- a/client/src/components/SideDrawer.js
+++ b/client/src/components/SideDrawer.js
@@ -4,6 +4,7 @@ import { logout } from '../services/auth';
 import CloseBtn from './CloseBtn';
 import Backdrop from './Backdrop';
 import SharedSnackbarContext from './SharedSnackbar.context';
+import SharedDialogContext from './SharedDialog.context';
 
 import './SideDrawer.scss';
 
@@ -20,6 +21,27 @@ const SideDrawer = (props) => {
   }
 
   const { openSnackbar } = useContext(SharedSnackbarContext);
+  const { openDialog } = useContext(SharedDialogContext);
+
+  const wishListAButton =  (
+    props.user ? (
+      <a href={`/apps/wishlist/${props.user._id}`}>Wish list</a>
+    ) : (
+      <button onClick={() => openDialog('Log in to create a wish list.')} className='sidebar-btn-link'>
+        Wish list
+     </button>
+    )
+  );
+
+  const welcomeMsg = (
+    props.user && (
+      <li className="user-name">
+            Hi,
+            {' '}
+            {props.user.username}
+          </li>
+    ) 
+  )
 
   const handleLogOut = () => {
     logout()
@@ -39,25 +61,31 @@ const SideDrawer = (props) => {
           <CloseBtn click={props.click} />
         </div>
         <ul>
-          <li className="user-name">
-            Hi
-            {' '}
-            {props.user.username}
+          {welcomeMsg}
+          <li>
+            <a href="/">Home</a>
           </li>
           <li>
             <a href="/apps/new">Add app</a>
           </li>
           <li>
-            <a href={`/apps/wishlist/${props.user._id}`}>Wish list</a>
+            {wishListAButton}
           </li>
           <li>
             <a href="/about">
               About
             </a>
           </li>
-          <li>
-            <button onClick={handleLogOut}>Log out</button>
-          </li>
+          {props.user ?
+            <li>
+              <button onClick={handleLogOut}>Log out</button>
+            </li> : 
+            <li>
+              <a href="/login" className='sidebar-a-btn'>
+                Log in
+              </a>
+            </li>
+          }
         </ul>
       </nav>
       {backdrop}

--- a/client/src/components/SideDrawer.scss
+++ b/client/src/components/SideDrawer.scss
@@ -42,8 +42,8 @@
 
 .side-drawer a {
     font-size: 1.8rem;
-    font-weight: 500;
-    color:$bodyGreen;
+    font-weight: 300;
+    color: $almostWhite;
 }
 
 .side-drawer button {
@@ -57,9 +57,9 @@
 }
 
 .user-name {
-    border-bottom: 1px solid $lightGray;
-    color: $lightGray;
-    font-size: 1.6rem;
+    border-bottom: 1px solid  $thinBodyGreen;
+    color:$bodyGreen;
+    font-size: 1.3rem;
     font-weight: 300;
 }
 
@@ -67,6 +67,27 @@
     align-self: flex-start;
     margin-top: 1rem;
 }
+
+.side-drawer .sidebar-btn-link {
+    border: none;
+    font-size: 1.8rem;
+    font-weight: 300;
+    color: $almostWhite;
+    display: block;
+    padding: 0;
+    font-family: 'Roboto';
+}
+
+.side-drawer .sidebar-a-btn {
+    padding: 10px 20px;
+    background-color: #2b2d42;
+    border: 1px solid #16db86;
+    font-size: 16px;
+    font-weight: 500;
+    color: $bodyGreen;
+    display: inline-block;
+}
+
 /* hide side-drawer items if larger than 601px */
 @media (min-width: 601px) {
     .side-drawer{

--- a/client/src/components/WishList.js
+++ b/client/src/components/WishList.js
@@ -13,40 +13,38 @@ function WishListHook(props) {
   const { openDialog } = useContext(SharedDialogContext);
 
   useEffect(() => {
-    if (!props.user) 
-    { openDialog('Log in to continue.') }    
-    else {
+    if (!props.user) { openDialog('Log in to continue.'); } else {
       fetchAllApps()
-      .then((apps) => {
-        setAppList(apps);
-      })
-      .catch((error) => {
-        alert(error.message);
-      });
+        .then((apps) => {
+          setAppList(apps);
+        })
+        .catch((error) => {
+          alert(error.message);
+        });
     }
   }, [setAppList]);
 
   const loggedInWishList = (
     <section id="listContainer" className="fadeIn">
-        {appList
-          .filter((app) => app.wishUser.includes(props.user._id))
-          .map((app) => (
-            <AppsList
-              appId={app._id}
-              src={app.logo || appIconPlaceholder}
-              appName={app.name}
-              appCategoryName={app.category.name}
-            />
-          ))}
+      {appList
+        .filter((app) => app.wishUser.includes(props.user._id))
+        .map((app) => (
+          <AppsList
+            appId={app._id}
+            src={app.logo || appIconPlaceholder}
+            appName={app.name}
+            appCategoryName={app.category.name}
+          />
+        ))}
     </section>
-  )
-  
+  );
+
   if (!appList) return <Loader />;
 
   return (
     <main>
       <h1>My wish list</h1>
-      { props.user && loggedInWishList  }
+      { props.user && loggedInWishList }
     </main>
   );
 }

--- a/client/src/components/WishList.js
+++ b/client/src/components/WishList.js
@@ -1,29 +1,33 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { fetchAllApps } from '../services/app';
 import appIconPlaceholder from '../app-icon-placeholder.svg';
 import Loader from './Loader';
 import AppsList from './AppsList';
 
+import SharedDialogContext from './SharedDialog.context';
+
 // fetch all apps, filter to wishUser_id includes props user id
 function WishListHook(props) {
   const [appList, setAppList] = useState([]);
 
+  const { openDialog } = useContext(SharedDialogContext);
+
   useEffect(() => {
-    fetchAllApps()
+    if (!props.user) 
+    { openDialog('Log in to continue.') }    
+    else {
+      fetchAllApps()
       .then((apps) => {
         setAppList(apps);
       })
       .catch((error) => {
         alert(error.message);
       });
+    }
   }, [setAppList]);
 
-  if (!appList) return <Loader />;
-
-  return (
-    <main>
-      <h1>My wish list</h1>
-      <section id="listContainer" className="fadeIn">
+  const loggedInWishList = (
+    <section id="listContainer" className="fadeIn">
         {appList
           .filter((app) => app.wishUser.includes(props.user._id))
           .map((app) => (
@@ -34,7 +38,15 @@ function WishListHook(props) {
               appCategoryName={app.category.name}
             />
           ))}
-      </section>
+    </section>
+  )
+  
+  if (!appList) return <Loader />;
+
+  return (
+    <main>
+      <h1>My wish list</h1>
+      { props.user && loggedInWishList  }
     </main>
   );
 }

--- a/client/src/components/style.scss
+++ b/client/src/components/style.scss
@@ -47,3 +47,7 @@ a:hover {
   color:$bodyGreen;
 }
 
+button:hover {
+  color:$bodyGreen;
+}
+


### PR DESCRIPTION
This pr: 
 - unlocks navbar and side drawer items to both logged-in and not-logged-in users; plus new design of side drawer. Users that are not logged-in will see the pop dialog asking them to log in when clicking on btns. 
-  redesign side drawers, including: add homepage item, change text color to _$almostwhite_, and align overall design.

This aims to attract more users to engage by showing more features.

