### PR TITLE
Remove max-height of container of mobile screen

### DIFF
--- a/client/src/components/About.scss
+++ b/client/src/components/About.scss
@@ -32,4 +32,7 @@ main#about {
       height: 80%;
       padding-top: 20px;
     }
+    .about-container {
+      max-height: initial;
+    }
   }


### PR DESCRIPTION
This pr removes the container's max-height of mobile screen. This aims to solve the problem that texts could overflow the container. 