### PR TITLE
make return arrow larger

### DIFF
--- a/client/src/components/About.scss
+++ b/client/src/components/About.scss
@@ -31,6 +31,7 @@ main#about {
       width: 80%;
       height: 80%;
       padding-top: 20px;
+      padding-bottom: 20px;
     }
     .about-container {
       max-height: initial;

--- a/client/src/components/NewApp.scss
+++ b/client/src/components/NewApp.scss
@@ -118,7 +118,7 @@ input
 
 .return-arrow {
   color: $bodyGreen;
-  font-size: 20px;
+  font-size: 26px;
   border: none;
   padding: 0;
 }


### PR DESCRIPTION
This pr fixes the size problem of the arrow symbol. The arrow is larger. 