### PR TITLE
Add sticky footer

### DIFF
--- a/client/src/components/Footer.scss
+++ b/client/src/components/Footer.scss
@@ -1,6 +1,6 @@
 @import './Colors.scss';
 
-/* TODO: sticky footer */
+/* sticky footer: see .wrapper in Loader*/
 footer {
     font-weight: 300;
     font-size: 14px;

--- a/client/src/components/HomePage.js
+++ b/client/src/components/HomePage.js
@@ -47,7 +47,7 @@ function HomePage() {
   if (!categories.length || !appsList.length) return <Loader/>;
 
   return (
-    <main className="">
+    <main>
       <h1>If you don't protect your privacy, who will?</h1>
       <h2>Find the right app to protect your privacy with OpenStock</h2>
       <Search setQuery={setQuery} queries={queries} />

--- a/client/src/components/Loader.js
+++ b/client/src/components/Loader.js
@@ -5,7 +5,7 @@ import { LoaderIcon } from '../images';
 import './Loader.scss';
 
 const loader = () => (
-  <div>
+  <div className="wrapper">
     <Backdrop />
     <div className="loading">
       <img src={LoaderIcon} alt="loading" />

--- a/client/src/components/Loader.scss
+++ b/client/src/components/Loader.scss
@@ -1,5 +1,11 @@
 @import './Colors.scss';
 
+.wrapper {
+  // sticky footer: loader fill remaining space of the page
+  // calc: saas feature, entire screen 100vh, minus header, footer, and margin
+  height: calc(100vh - 104px - 47px - 48px)
+}
+
 .loading img {
     width: 100%;
     height: 100%;
@@ -16,10 +22,10 @@
   animation-iteration-count: infinite;
   animation-fill-mode: none;
   animation-play-state: running;
-  //
+  // center loader
   position: absolute;
   top: 50%;
-  left: 45%;
+  left: 47%;
   transform: translate(-50%, -50%);
 }
 


### PR DESCRIPTION
This pr adds a sticky footer. 
The footer was above the loader when the loader displays; to fix this UI bug, it adds a wrapper to fill the remaining space of the page by applying sass calc property. 