### PR TITLE
Save active index of categories carousel

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16999,12 +16999,11 @@
       }
     },
     "react-alice-carousel": {
-      "version": "1.19.3",
-      "resolved": "https://registry.npmjs.org/react-alice-carousel/-/react-alice-carousel-1.19.3.tgz",
-      "integrity": "sha512-FaOQ/f7C/4cBuXr2tA4YgVyVrvWI7VbccGxJpu+rCsnnUlcN0YLz+20iJ2TFCXJp9M+/FjBratUNC7vQBrMQPw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-alice-carousel/-/react-alice-carousel-2.2.2.tgz",
+      "integrity": "sha512-hk4QyPDZtHh03avuNBuT/A+CojFdPyB/xi3wehyta+e0EvzlxS8286u82/IkWt4TceGcTWHCltdes6u/DNBgkQ==",
       "requires": {
-        "prop-types": "^15.5.10",
-        "vanilla-swipe": "1.2.0"
+        "vanilla-swipe": "^2.2.0"
       }
     },
     "react-app-polyfill": {
@@ -20482,9 +20481,9 @@
       "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vanilla-swipe": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/vanilla-swipe/-/vanilla-swipe-1.2.0.tgz",
-      "integrity": "sha512-1yNnsfHcl67Y24HGJc/zrC9omRBzzxqvC6D5apOXMqGukuz0Zha1ydKJM7AUL/dB2w7Bd7UsI2Uw7+AE4soDaA=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/vanilla-swipe/-/vanilla-swipe-2.3.0.tgz",
+      "integrity": "sha512-4m8vZ/kckRG7RQUYNg+0lGILMHT08KEgwePlRLzediDSu7aQFBLB0V2n36vUmYqq5CVWASOzZ8zpnQFZXIbHbA=="
     },
     "vary": {
       "version": "1.1.2",

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
     "@material-ui/core": "^4.11.0",
     "axios": "^0.21.1",
     "react": "^16.13.1",
-    "react-alice-carousel": "^1.19.3",
+    "react-alice-carousel": "^2.2.2",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^3.4.3"

--- a/client/src/components/Categories.js
+++ b/client/src/components/Categories.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import AliceCarousel from 'react-alice-carousel';
 // icons contains map of key-value/name-image pairs in index.js
 import * as icons from '../images';
@@ -9,8 +9,14 @@ import PropTypes from 'prop-types';
 import './Categories.scss';
 
 function Categories({ categories, selectedCategory, onCategoryChange }) {
+  const [activeIndex, setActiveIndex] = useState(0);
+
   const handleCategory = (categoryId) => {
     onCategoryChange(categoryId);
+  };
+
+  const handleSlideChange = (event) => {
+    setActiveIndex(event.item);
   };
 
   const responsive = {
@@ -58,11 +64,11 @@ function Categories({ categories, selectedCategory, onCategoryChange }) {
         duration={250}
         fadeOutAnimation
         mouseTrackingEnabled
-        swipeDisabled={false}
-        touchTrackingEnabled
         infinite={false}
         // disbale prev&next btns
-        buttonsDisabled
+        disableButtonsControls
+        activeIndex={activeIndex}
+        onSlideChanged={handleSlideChange}
       />
     </section>
   );


### PR DESCRIPTION
This PR updates alice carousel package and saves active index of the category item. 
It fixes the issue that the active index prop did not work. 